### PR TITLE
(Fossil Fuels, Electricity & Water) Update to % of Estimated Consumption

### DIFF
--- a/Chapters/001_kmsimg_fossilfuels.md
+++ b/Chapters/001_kmsimg_fossilfuels.md
@@ -24,7 +24,7 @@ Emissions associated with the combustion of any gaseous, liquid, and solid fossi
 | Description of data available  | Reduced calculation [RC]  | Standard calculation [SC] | Optimal calculation [OC] |
 | ------------------------------ |:---:| :---:| :---:|
 | Modelled energy consumption | X |  |  |
-| Monitored annual consumption, ≥11% estimated (kWh) |  | X |  |
+| Monitored annual consumption, >10% estimated (kWh) |  | X |  |
 | Monitored annual consumption, ≤10% estimated (kWh) |  |  | X |
 
 **Reduced calculation: Natural gas**
@@ -51,7 +51,7 @@ $$
 $$
 
 Where:
-* EstMonCon = Value of monitored annual energy use (kWh) where ≥11% of data are estimated.
+* EstMonCon = Value of monitored annual energy use (kWh) where >10% of data are estimated.
 * FuelFac = Carbon factor assigned to the fuel by the relevant BEIS carbon factor database publication.  
 
 **Optimal calculation: Natural gas**

--- a/Chapters/005_kmsimg_electricity.md
+++ b/Chapters/005_kmsimg_electricity.md
@@ -27,7 +27,7 @@ Emissions associated with the generation of electricity consumed at owned sites 
 | Description of data available  | Reduced calculation [RC]  | Standard calculation [SC] | Optimal calculation [OC] |
 | ------------------------------ |:---:| :---:| :---:|
 | Modelled electricity consumption | X |  |  |
-| Monitored annual consumption, $\geq$ 11% estimated (kWh) |  | X |  |
+| Monitored annual consumption, &gt; 10% estimated (kWh) |  | X |  |
 | Monitored annual consumption, $\leq$ 10% estimated (kWh) |  |  | X |
 
 **Reduced calculation: Electricity**
@@ -55,7 +55,7 @@ $$
 $$
 
 Where:
-* EstMonCon = Value of monitored annual electricity use (kWh) where ≥11% of data are estimated.
+* EstMonCon = Value of monitored annual electricity use (kWh) where >10% of data are estimated.
 * GenFac = Carbon factor assigned to the fuel by the relevant BEIS carbon factor database publication.
 
 **Optimal calculation: Electricity**

--- a/Chapters/009_kmsimg_water.md
+++ b/Chapters/009_kmsimg_water.md
@@ -23,7 +23,7 @@ Emissions associated with the supply and treatment of water at owned sites and t
 | Description of data available  | Reduced calculation [RC]  | Standard calculation [SC] | Optimal Calculation [OC] |
 | ------------------------------ |:---:| :---:| :---:|
 | Water supply and treatment billing (£) | X |  |  |
-| Monitored annual consumption, ≥11% estimated (m<sup>3</sup>) |  | X |  |
+| Monitored annual consumption, >10% estimated (m<sup>3</sup>) |  | X |  |
 | Monitored annual consumption, ≤10% estimated (m<sup>3</sup>) |  |  | X |
 
 **Reduced calculation: Water**
@@ -50,7 +50,7 @@ $$
 $$
 
 Where:
-* WatSuppVol = The volume of water supplied (m<sup>3</sup>) where ≥11% estimated.
+* WatSuppVol = The volume of water supplied (m<sup>3</sup>) where >10% estimated.
 * WatSuppFac = The value assigned to emissions associted with supply of water from a date relevant dataset (kgCO<sub>2</sub>e/m<sup>3</sup>).
 * WatTreatVol = The volume of water treated (m<sup>3</sup>).
 * WatTreatFac = The value assigned to emissions associted with treatment of water from a date relevant dataset (kgCO<sub>2</sub>e/m<sup>3</sup>).


### PR DESCRIPTION
SC pertains to calculations where ≥11% of kWh/m3 is estimated and OC pertains to ≤10% estimated consumption.

Changed SC to >10% to account for percentage point in between 10% and 11%.

Quite likely an unnecessary change as percentage of estimated kWh/m3 can be rounded to apply formulas as they were.